### PR TITLE
Update JavaParser to the latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <api.version>1.3.1</api.version>
         <maven.version>3.2.2</maven.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <prerequisites>
@@ -131,7 +133,7 @@
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
-            <version>2.0.0</version>
+            <version>3.1.4</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
As maintainer of the JavaParser project I would like to see people move away from version 2. It doesn't look like this project is getting a lot of love, but here is the update anyway.

Note that it includes an upgrade to Java 8, which you may not want. In that case you can easily update JavaParser to 2.5.1.